### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube-auto-updater.yml
+++ b/.github/workflows/sonarqube-auto-updater.yml
@@ -1,5 +1,8 @@
 name: Automated SonarQube Update Checker
 
+permissions:
+    contents: read
+
 on:
     schedule:
         # Run daily at 00:00 UTC
@@ -9,6 +12,8 @@ on:
 
 jobs:
     update-test-and-push:
+        permissions:
+            contents: write
         runs-on: ubuntu-latest
         outputs:
             version_updated: ${{ steps.commit-push.outputs.did_push }}
@@ -93,6 +98,8 @@ jobs:
                   echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     release-after-update:
+        permissions:
+            contents: read
         needs: update-test-and-push
         if: needs.update-test-and-push.outputs.version_updated == 'true'
         uses: ./.github/workflows/release.yml


### PR DESCRIPTION
Potential fix for [https://github.com/lubond/sonarqube-aem/security/code-scanning/5](https://github.com/lubond/sonarqube-aem/security/code-scanning/5)

Add explicit `permissions` blocks to limit `GITHUB_TOKEN` scope:

1. **Workflow-level default**: add a root `permissions` block with minimal read access (`contents: read`) so all jobs are restricted by default.
2. **Job-level override for push job**: add `permissions` under `jobs.update-test-and-push` with `contents: write`, since this job commits and pushes.
3. **Job-level override for reusable workflow caller**: add `permissions` under `jobs.release-after-update` with `contents: read` (minimum safe baseline from shown snippet).  
   - If `release.yml` needs more, it should request them explicitly in that workflow; but based only on shown code, `contents: read` is the least-privilege choice.

Only edit `.github/workflows/sonarqube-auto-updater.yml` in the shown regions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
