### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lubond/sonarqube-aem/security/code-scanning/4](https://github.com/lubond/sonarqube-aem/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
For this workflow, the minimal required permission is:

- `contents: read` (needed by `actions/checkout`)

No other GitHub API write scopes are required by the shown steps (Docker Hub auth/build/push use external secrets and registry).  
So the best fix is to insert:

```yml
permissions:
  contents: read
```

directly after the `on:` section (or before `jobs:`), so it applies to `build` and any future jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
